### PR TITLE
MacOS Bug Fix for Sound File Paths with Spaces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const { exec } = require('child_process')
 const execPromise = require('util').promisify(exec)
 
 /* MAC PLAY COMMAND */
-const macPlayCommand = path => `afplay ${path}`
+const macPlayCommand = path => `afplay \"${path}\"`
 
 /* WINDOW PLAY COMMANDS */
 const addPresentationCore = `Add-Type -AssemblyName presentationCore;`


### PR DESCRIPTION
If a file path was given on macOS where there was a space, this resulted in "afplay" expecting multiple files to play. This causes the command to fail. Proposed change is adding quotation marks around the file path which is common practice for UNIX systems.