### PR TITLE
Remove powershell popup with PM2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ module.exports = {
     const playCommand =
       process.platform === 'darwin' ? macPlayCommand(path, volumeAdjustedByOS) : windowPlayCommand(path, volumeAdjustedByOS)
     try {
-      await execPromise(playCommand)
+      await execPromise(playCommand, {windowsHide: true})
     } catch (err) {
       throw err
     }


### PR DESCRIPTION
When using PM2 we get a powershell window that opens then closes once audio completes.
Adding "windowsHide: true" makes sure no window opens when starting a process from node.