### PR TITLE
Functionality expansion to include Stop & Loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "babel-loader": "^8.0.6",
-    "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.9"
+    "terser-webpack-plugin": "^5.3.10",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,36 +1,46 @@
-const { exec } = require('child_process')
-const execPromise = require('util').promisify(exec)
+const { exec } = require('child_process');
+const execPromise = require('util').promisify(exec);
 
-/* MAC PLAY COMMAND */
-const macPlayCommand = (path, volume) => `afplay \"${path}\" -v ${volume}`
 
-/* WINDOW PLAY COMMANDS */
+//WINDOWS
 const addPresentationCore = `Add-Type -AssemblyName presentationCore;`
 const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`
+const stopPowerShell = `taskkill /F /IM powershell.exe`;
 const loadAudioFile = path => `$player.open('${path}');`
 const playAudio = `$player.Play();`
 const stopAudio = `Start-Sleep 1; Start-Sleep -s $player.NaturalDuration.TimeSpan.TotalSeconds;Exit;`
+const loopAudio = `while ($true) { Start-Sleep -Milliseconds 100; if ($player.Position -ge $player.NaturalDuration.TimeSpan) { $player.Position = [TimeSpan]::Zero; $player.Play(); }};`
 
-const windowPlayCommand = (path, volume) =>
-  `powershell -c ${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
-    path,
-  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`
+const windowPlayCommand = (path, volume, loop) => `powershell -c ${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(path)} $player.Volume = ${volume}; ${playAudio} ${loop?loopAudio:stopAudio}`;
+const windowStopCommand = ()=> `${stopPowerShell}`;
+
+
+//MAC
+const macPlayCommand = (path, volume, loop) => `afplay -v ${volume} ${loop ? '-r' : ''} \"${path}\"`;
+const macStopCommand = () => `pkill afplay`;
 
 module.exports = {
-  play: async (path, volume=0.5) => {
-    /**
-     * Window: mediaplayer's volume is from 0 to 1, default is 0.5
-     * Mac: afplay's volume is from 0 to 255, default is 1. However, volume > 2 usually result in distortion.
-     * Therefore, it is better to limit the volume on Mac, and set a common scale of 0 to 1 for simplicity
-     */
-    const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume
+  play: async (path, volume = 0.5, loop = false) => {
+    const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume;
 
     const playCommand =
-      process.platform === 'darwin' ? macPlayCommand(path, volumeAdjustedByOS) : windowPlayCommand(path, volumeAdjustedByOS)
+        process.platform === 'darwin'
+            ? macPlayCommand(path, volumeAdjustedByOS, loop)
+            : windowPlayCommand(path, volumeAdjustedByOS, loop);
+
     try {
-      await execPromise(playCommand, {windowsHide: true})
+      await execPromise(playCommand);
     } catch (err) {
-      throw err
+      throw err;
     }
   },
-}
+
+  stop: async () => {
+    const stopCommand = process.platform === 'darwin' ? macStopCommand() : windowStopCommand() ;
+    try {
+      await execPromise(stopCommand);
+    } catch (err) {
+      throw err;
+    }
+  },
+};


### PR DESCRIPTION
Hello,
I have taken the liberty of extending your product for a project of mine. I have extended one function and added a new one. Specifically, I have added the functionality to play an audio file as a loop and to stop the audio. The function to stop the audio is clumsily implemented.
The changes were only tested in a NodeJS application under Node version 19.0.0 on Windows 11. However, the extension also includes the corresponding commands for MAC, but these have not been tested.