### PR TITLE
Support stopping playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ _Dead simple sound player for Node -- because it should be simple._
 
 ```javascript
 const sound = require("sound-play");
-sound.play("file.mp3");
+const player = sound.player("file.mp3");
+player.play();
+
+// Optional way to stop playing
+player.stop();
 ```
+
 - Native solution. Does not require third-party application to work on `Windows` and `MacOS`.
 
 - Support `.wav`, `.mp3` and other extensions.
-
 
 # Install
 
@@ -26,7 +30,7 @@ yarn add sound-play
 ### Relative path
 
 ```javascript
-sound.play("file.mp3");
+sound.player("file.mp3").play();
 ```
 
 or
@@ -34,7 +38,7 @@ or
 ```javascript
 const path = require("path");
 const filePath = path.join(__dirname, "file.mp3");
-sound.play(filePath);
+sound.player(filePath).play();
 ```
 
 ### Adjusting Volume
@@ -46,7 +50,7 @@ sound.play(filePath);
  * 1   = max volume
  */
 volume = 0.1;
-sound.play("file.mp3", volume);
+sound.player("file.mp3", volume).play();
 ```
 
 ### Adjusting Speed Rate (Mac only)
@@ -56,26 +60,36 @@ sound.play("file.mp3", volume);
  * 1 = normal | > 1 faster
  */
 rate = 1.5;
-sound.play("file.mp3", 0.5, rate);
+sound.player("file.mp3", 0.5, rate).play();
 ```
 
 ### Absolute path
 
 ```javascript
-sound.play("C:\\file.mp3");
+sound.player("C:\\file.mp3").play();
 ```
 
 ### Promise
 
 ```javascript
-sound.play("file.mp3").then((response) => console.log("done"));
+sound
+  .player("file.mp3")
+  .play()
+  .then((response) => console.log("done"));
 ```
 
 ### Async/await
 
 ```javascript
 try {
-  await sound.play("file.mp3");
+  const player = sound.player("file.mp3");
+
+  // Optional way to stop the sound playing before it was supposed to end
+  setTimeout(() => {
+    player.stop();
+  }, 5000);
+
+  await player.play();
   console.log("done");
 } catch (error) {
   console.error(error);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "sound-play",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An sound player for NodeJS.",
-  "main": "build/main.js",
+  "main": "src/index.js",
   "scripts": {
     "build": "webpack --config webpack.config.js"
   },
+  "types": "src/index.d.ts",
+  "files": [
+    "src/index.js",
+    "src/index.d.ts"
+  ],
   "author": "nomadhoc",
   "repository": "nomadhoc/sound-play",
   "bugs": {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,24 @@
+import { ChildProcess } from 'child_process';
+
+export interface PlayerInstance {
+  /** Stops playback by killing the child process */
+  stop(): void;
+
+  /** Promise that resolves when playback finishes */
+  play(): Promise<void>;
+
+  /** The spawned child process running the playback command */
+  process: ChildProcess;
+}
+
+/**
+ * Creates a new audio player instance for the given file path.
+ * @param path Path to the audio file
+ * @param volume Playback volume (0.0 to 1.0, default 0.5)
+ * @param rate Playback rate (default 1.0)
+ */
+export function player(
+  path: string,
+  volume?: number,
+  rate?: number
+): PlayerInstance; 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function execWithChild(command, options = {}) {
     });
   });
 
-const originalKill = child.kill.bind(child);
+  const originalKill = child.kill.bind(child);
   child.kill = (signal = 'SIGTERM') => {
     try {
       // A negative PID tells Node to signal the entire process group.
@@ -22,22 +22,37 @@ const originalKill = child.kill.bind(child);
     }
   };
 
-  return { promise, child };}
+  return { promise, child };
+}
 
 /* MAC PLAY COMMAND */
 const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`;
 
-/* WINDOW PLAY COMMANDS */
+/* WINDOWS PLAY COMMANDS */
 const addPresentationCore = `Add-Type -AssemblyName presentationCore;`;
-const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`;
-const loadAudioFile = path => `$player.open('${path}');`;
-const playAudio = `$player.Play();`;
-const stopAudio = `Start-Sleep 1; Start-Sleep -s $player.NaturalDuration.TimeSpan.TotalSeconds;Exit;`;
+const createMediaPlayer   = `$player = New-Object system.windows.media.mediaplayer;`;
+const loadAudioFile       = path => `$player.open('${path}');`;
+const playAudio           = `$player.Play();`;
+
+/**
+ * Wait until the MediaPlayer finishes playing.
+ *
+ * PowerShell does not have a built‑in “await” for MediaPlayer, so we poll
+ * `Position` against `NaturalDuration`.  The loop sleeps a short amount of
+ * time (200 ms) to avoid busy‑waiting but still reacts quickly when we kill the
+ * process from Node.
+ */
+const waitForEnd = `
+while ($player.Position -lt $player.NaturalDuration) {
+    Start-Sleep -Milliseconds 200
+}
+`;
 
 const windowPlayCommand = (path, volume) =>
-  `powershell -c ${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
+  `powershell -NoProfile -Command "` +
+  `${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
     path,
-  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`;
+  )} $player.Volume = ${volume}; ${playAudio} ${waitForEnd}"`;
 
 /**
  * Plays an audio file on Mac or Windows

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 const execPromise = require('util').promisify(exec);
 
 // Functionality to give caller the ability to stop playing
@@ -11,17 +11,6 @@ function execWithChild(command, options = {}) {
     });
   });
 
-  const originalKill = child.kill.bind(child);
-  child.kill = (signal = 'SIGTERM') => {
-    try {
-      // A negative PID tells Node to signal the entire process group.
-      process.kill(-child.pid, signal);
-    } catch (_) {
-      // If that fails for any reason fall back to killing just the shell.
-      originalKill(signal);
-    }
-  };
-
   return { promise, child };
 }
 
@@ -30,29 +19,13 @@ const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} 
 
 /* WINDOWS PLAY COMMANDS */
 const addPresentationCore = `Add-Type -AssemblyName presentationCore;`;
-const createMediaPlayer   = `$player = New-Object system.windows.media.mediaplayer;`;
-const loadAudioFile       = path => `$player.open('${path}');`;
-const playAudio           = `$player.Play();`;
+const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`;
+const loadAudioFile = path => `$player.open('${path}');`;
+const setMediaEndedHandler = `Register-ObjectEvent $player MediaEnded -Action { Write-Output 'DONE' } | Out-Null;`;
+const playAudio = `$player.Play();`;
 
-/**
- * Wait until the MediaPlayer finishes playing.
- *
- * PowerShell does not have a built‑in “await” for MediaPlayer, so we poll
- * `Position` against `NaturalDuration`.  The loop sleeps a short amount of
- * time (200 ms) to avoid busy‑waiting but still reacts quickly when we kill the
- * process from Node.
- */
-const waitForEnd = `
-while ($player.Position -lt $player.NaturalDuration) {
-    Start-Sleep -Milliseconds 200
-}
-`;
-
-const windowPlayCommand = (path, volume) =>
-  `powershell -NoProfile -Command "` +
-  `${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
-    path,
-  )} $player.Volume = ${volume}; ${playAudio} ${waitForEnd}"`;
+const windowsPlayCommand = (path, volume) =>
+  `${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(path)} $player.Volume = ${volume}; ${setMediaEndedHandler}`;
 
 /**
  * Plays an audio file on Mac or Windows
@@ -69,24 +42,51 @@ module.exports = {
   player: (path, volume=0.5, rate=1) => {
     const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume;
 
-    const playCommand =
-      process.platform === 'darwin'
-      ? macPlayCommand(path, volumeAdjustedByOS, rate)
-      : windowPlayCommand(path, volumeAdjustedByOS);
+    if (process.platform === 'darwin') {
+      const playCommand = macPlayCommand(path, volumeAdjustedByOS, rate);
+      const { promise, child } = execWithChild(playCommand, { windowsHide: true });
+      
+      return {
+        stop: () => child.kill(),
+        play: async () => {
+          try {
+            const result = await promise;
+            return result;
+          } catch (error) {
+            throw error;
+          }
+        },
+        process: child
+      };
+    } else {
+      // Windows: PowerShell session, resolves on MediaEnded, cleans up after
+      const child = spawn("powershell.exe", ["-NoExit", "-Command", windowsPlayCommand(path, volumeAdjustedByOS)], {
+        windowsHide: true,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
 
-    const { promise, child } = execWithChild(playCommand, { windowsHide: true });
-    
-    return {
-      stop: () => child.kill(),
-      play: async () => {
-        try {
-          const result = await promise;
-          return result;
-        } catch (error) {
-          throw error;
+      let resolver;
+      const promise = new Promise((resolve) => { resolver = resolve; });
+
+      child.stdout.on("data", (data) => {
+        if (data.toString().includes("DONE")) {
+          resolver("Playback finished");
+          child.kill();
         }
-      },
-      process: child
-    };
+      });
+
+      return {
+        stop: () => {
+          child.stdin.write("$player.Stop()\n");
+          resolver("Playback stopped");
+          child.kill();
+        },
+        play: async () => {
+          child.stdin.write(playAudio + "\n");
+          return promise;
+        },
+        process: child
+      };
+    }
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,14 @@ module.exports = {
     
     return {
       stop: () => child.kill(),
-      play: () => promise, 
+      play: async () => {
+        try {
+          const result = await promise;
+          return result;
+        } catch (error) {
+          throw error;
+        }
+      },
       process: child
     };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} 
 const addPresentationCore = `Add-Type -AssemblyName presentationCore;`;
 const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`;
 const loadAudioFile = path => `$player.open('${path}');`;
-const setMediaEndedHandler = `Register-ObjectEvent $player MediaEnded -Action { Write-Output 'DONE' } | Out-Null;`;
+const setMediaEndedHandler = `Register-ObjectEvent $player MediaEnded -Action { Write-Host 'DONE' } | Out-Null;`;
 const playAudio = `$player.Play();`;
 
 const windowsPlayCommand = (path, volume) =>

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,24 @@ const execPromise = require('util').promisify(exec);
 function execWithChild(command, options = {}) {
   let child;
   const promise = new Promise((resolve, reject) => {
-    child = exec(command, options, (error, stdout, stderr) => {
+    child = exec(command, { ...options, detached: true }, (error, stdout, stderr) => {
       if (error) return reject(error);
       resolve(stdout);
     });
   });
 
-  return { promise, child };
-}
+const originalKill = child.kill.bind(child);
+  child.kill = (signal = 'SIGTERM') => {
+    try {
+      // A negative PID tells Node to signal the entire process group.
+      process.kill(-child.pid, signal);
+    } catch (_) {
+      // If that fails for any reason fall back to killing just the shell.
+      originalKill(signal);
+    }
+  };
+
+  return { promise, child };}
 
 /* MAC PLAY COMMAND */
 const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,33 @@
-const { exec } = require('child_process')
-const execPromise = require('util').promisify(exec)
+const { exec } = require('child_process');
+const execPromise = require('util').promisify(exec);
+
+// Functionality to give caller the ability to stop playing
+function execWithChild(command, options = {}) {
+  let child;
+  const promise = new Promise((resolve, reject) => {
+    child = exec(command, options, (error, stdout, stderr) => {
+      if (error) return reject(error);
+      resolve(stdout);
+    });
+  });
+
+  return { promise, child };
+}
 
 /* MAC PLAY COMMAND */
-const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`
+const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`;
 
 /* WINDOW PLAY COMMANDS */
-const addPresentationCore = `Add-Type -AssemblyName presentationCore;`
-const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`
-const loadAudioFile = path => `$player.open('${path}');`
-const playAudio = `$player.Play();`
-const stopAudio = `Start-Sleep 1; Start-Sleep -s $player.NaturalDuration.TimeSpan.TotalSeconds;Exit;`
+const addPresentationCore = `Add-Type -AssemblyName presentationCore;`;
+const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`;
+const loadAudioFile = path => `$player.open('${path}');`;
+const playAudio = `$player.Play();`;
+const stopAudio = `Start-Sleep 1; Start-Sleep -s $player.NaturalDuration.TimeSpan.TotalSeconds;Exit;`;
 
 const windowPlayCommand = (path, volume) =>
   `powershell -c ${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
     path,
-  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`
+  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`;
 
 /**
  * Plays an audio file on Mac or Windows
@@ -28,18 +41,20 @@ const windowPlayCommand = (path, volume) =>
  * @throws Will throw an error if audio playback fails.
  */
 module.exports = {
-  play: async (path, volume=0.5, rate=1) => {
-    const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume
+  player: (path, volume=0.5, rate=1) => {
+    const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume;
 
     const playCommand =
       process.platform === 'darwin'
       ? macPlayCommand(path, volumeAdjustedByOS, rate)
       : windowPlayCommand(path, volumeAdjustedByOS);
 
-    try {
-      await execPromise(playCommand, {windowsHide: true})
-    } catch (err) {
-      throw err
-    }
-  },
-}
+    const { promise, child } = execWithChild(playCommand, { windowsHide: true });
+    
+    return {
+      stop: () => child.kill(),
+      play: () => promise, 
+      process: child
+    };
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,92 +1,102 @@
-const { exec, spawn } = require('child_process');
-const execPromise = require('util').promisify(exec);
-
-// Functionality to give caller the ability to stop playing
-function execWithChild(command, options = {}) {
-  let child;
-  const promise = new Promise((resolve, reject) => {
-    child = exec(command, { ...options, detached: true }, (error, stdout, stderr) => {
-      if (error) return reject(error);
-      resolve(stdout);
-    });
-  });
-
-  return { promise, child };
-}
+const { spawn } = require('child_process')
 
 /* MAC PLAY COMMAND */
-const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`;
+const macPlayCommand = (path, volume, rate) => `afplay \"${path}\" -v ${volume} -r ${rate}`
 
-/* WINDOWS PLAY COMMANDS */
-const addPresentationCore = `Add-Type -AssemblyName presentationCore;`;
-const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`;
-const loadAudioFile = path => `$player.open('${path}');`;
-const setMediaEndedHandler = `Register-ObjectEvent $player MediaEnded -Action { Write-Host 'DONE' } | Out-Null;`;
-const playAudio = `$player.Play();`;
+/* WINDOW PLAY COMMANDS */
+const addPresentationCore = `Add-Type -AssemblyName presentationCore;`
+const createMediaPlayer = `$player = New-Object system.windows.media.mediaplayer;`
+const loadAudioFile = path => `$player.open('${path}');`
+const playAudio = `$player.Play();`
+const stopAudio = `Start-Sleep 1; Start-Sleep -s $player.NaturalDuration.TimeSpan.TotalSeconds;Exit;`
 
-const windowsPlayCommand = (path, volume) =>
-  `${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(path)} $player.Volume = ${volume}; ${setMediaEndedHandler}`;
+const windowPlayCommand = (path, volume) =>
+  `powershell -c ${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
+    path,
+  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`
+
+// Script-only (same as above but without the leading "powershell -c")
+const windowPlayScript = (path, volume) =>
+  `${addPresentationCore} ${createMediaPlayer} ${loadAudioFile(
+    path,
+  )} $player.Volume = ${volume}; ${playAudio} ${stopAudio}`
 
 /**
- * Plays an audio file on Mac or Windows
+ * Creates an audio player object on Mac or Windows.
  *
- * @param {string} path - The file path to the audio file that will be played.
- * @param {number} [volume=0.5] - Playback volume as a decimal between 0 and 1.
- *  - Windows: Volume range is 0 to 1. Default is 0.5.
- *  - Mac: Volume range is scaled from 0 to 2 (where 2 is 100% volume). Values above 2 may cause distortion.
- * @param {number} [rate=1] - Playback rate multiplier (only used on Mac). 1 is normal speed.
- * 
- * @throws Will throw an error if audio playback fails.
+ * @param {string} path
+ * @param {number} [volume=0.5]  // Win 0..1; Mac scaled to 0..2
+ * @param {number} [rate=1]      // Mac only
  */
 module.exports = {
-  player: (path, volume=0.5, rate=1) => {
-    const volumeAdjustedByOS = process.platform === 'darwin' ? Math.min(2, volume * 2) : volume;
+  player: (path, volume = 0.5, rate = 1) => {
+    const volumeAdjustedByOS =
+      process.platform === 'darwin' ? Math.min(2, volume * 2) : volume
 
-    if (process.platform === 'darwin') {
-      const playCommand = macPlayCommand(path, volumeAdjustedByOS, rate);
-      const { promise, child } = execWithChild(playCommand, { windowsHide: true });
-      
-      return {
-        stop: () => child.kill(),
-        play: async () => {
-          try {
-            const result = await promise;
-            return result;
-          } catch (error) {
-            throw error;
-          }
-        },
-        process: child
-      };
-    } else {
-      // Windows: PowerShell session, resolves on MediaEnded, cleans up after
-      const child = spawn("powershell.exe", ["-NoExit", "-Command", windowsPlayCommand(path, volumeAdjustedByOS)], {
-        windowsHide: true,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
+    let child = null
+    let playing = false
+    let playPromise = null
 
-      let resolver;
-      const promise = new Promise((resolve) => { resolver = resolve; });
-
-      child.stdout.on("data", (data) => {
-        if (data.toString().includes("DONE")) {
-          resolver("Playback finished");
-          child.kill();
-        }
-      });
-
-      return {
-        stop: () => {
-          child.stdin.write("$player.Stop()\n");
-          resolver("Playback stopped");
-          child.kill();
-        },
-        play: async () => {
-          child.stdin.write(playAudio + "\n");
-          return promise;
-        },
-        process: child
-      };
+    const spawnProcess = () => {
+      if (process.platform === 'darwin') {
+        // Use afplay directly so signals stop playback
+        return spawn(
+          'afplay',
+          [path, '-v', String(volumeAdjustedByOS), '-r', String(rate)],
+          { stdio: 'ignore', windowsHide: true }
+        )
+      }
+      // Windows: keep using System.Windows.Media.MediaPlayer via PowerShell
+      const script = windowPlayScript(path, volumeAdjustedByOS)
+      return spawn(
+        'powershell',
+        ['-NoProfile', '-NonInteractive', '-Command', script],
+        { stdio: 'ignore', windowsHide: true }
+      )
     }
-  }
-};
+
+    const play = () => {
+      if (playing) return playPromise
+      child = spawnProcess()
+      playing = true
+
+      playPromise = new Promise((resolve, reject) => {
+        child.once('error', (err) => {
+          playing = false
+          child = null
+          reject(err)
+        })
+        child.once('exit', (code, signal) => {
+          playing = false
+          const wasKilled = !!signal
+          const okExit = code === 0 && !wasKilled
+          child = null
+          okExit ? resolve() : reject(new Error(wasKilled ? 'Playback stopped' : `Playback failed (code ${code})`))
+        })
+      })
+
+      return playPromise
+    }
+
+    const stop = () => {
+      if (!child) return false
+      try {
+        if (process.platform === 'win32') {
+          // Kill PowerShell and its children to ensure MediaPlayer stops
+          spawn('taskkill', ['/PID', String(child.pid), '/T', '/F'], {
+            stdio: 'ignore',
+            windowsHide: true,
+          })
+        } else {
+          // macOS: send SIGTERM to afplay (direct child), fallback to SIGKILL
+          if (!child.kill('SIGTERM')) child.kill('SIGKILL')
+        }
+        return true
+      } catch {
+        return false
+      }
+    }
+
+    return { play, stop }
+  },
+}


### PR DESCRIPTION
Now returns a player object with a stop() function.

You can call sound.player(path).play() to play audio - just as you would call sound.play(path) in the past - but while audio is playing you can call stop() on the player object to stop playback.